### PR TITLE
elasticsearch-highlevel-client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,15 +193,20 @@
 			<version>13.0</version>
 		</dependency>
 
-        <!-- OpenSearch Java High level REST API -->
+        <!-- OpenSearch Java REST API -->
         <!-- https://mvnrepository.com/artifact/org.opensearch.client/opensearch-rest-client -->
         <dependency>
             <groupId>org.opensearch.client</groupId>
             <artifactId>opensearch-rest-client</artifactId>
             <version>1.2.4</version>
         </dependency>
+		<dependency>
+			<groupId>org.opensearch.client</groupId>
+			<artifactId>opensearch-rest-high-level-client</artifactId>
+			<version>2.2.0</version>
+		</dependency>
 
-        <!-- https://mvnrepository.com/artifact/com.amazonaws.auth/aws-java-sdk -->
+		<!-- https://mvnrepository.com/artifact/com.amazonaws.auth/aws-java-sdk -->
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>

--- a/src/main/java/gov/nih/nci/bento/model/ConfigurationDAO.java
+++ b/src/main/java/gov/nih/nci/bento/model/ConfigurationDAO.java
@@ -80,7 +80,10 @@ public class ConfigurationDAO {
 	private boolean esFilterEnabled;
 	@Value("${es.sign.requests:true}")
 	private boolean esSignRequests;
-
+	@Value("${es.service_name}")
+	private String serviceName;
+	@Value("${es.region}")
+	private String region;
 	//Testing
 	@Value("${test.queries_file}")
 	private String testQueriesFile;

--- a/src/main/java/gov/nih/nci/bento/service/ESService.java
+++ b/src/main/java/gov/nih/nci/bento/service/ESService.java
@@ -1,32 +1,22 @@
 package gov.nih.nci.bento.service;
 
-import com.amazonaws.auth.AWS4Signer;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.http.AWSRequestSigningApacheInterceptor;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
+import com.google.gson.*;
 import gov.nih.nci.bento.model.ConfigurationDAO;
-import org.apache.http.HttpHost;
-import org.apache.http.HttpRequestInterceptor;
+import gov.nih.nci.bento.service.connector.AWSClient;
+import gov.nih.nci.bento.service.connector.AbstractClient;
+import gov.nih.nci.bento.service.connector.DefaultClient;
 import org.apache.http.util.EntityUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.RestClient;
+import org.opensearch.client.RestHighLevelClient;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PreDestroy;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 @Service("ESService")
 public class ESService {
@@ -35,37 +25,21 @@ public class ESService {
     public static final String AGGS = "aggs";
     public static final int MAX_ES_SIZE = 10000;
 
-    static final AWSCredentialsProvider credentialsProvider = new DefaultAWSCredentialsProviderChain();
-
     private static final Logger logger = LogManager.getLogger(RedisService.class);
-
 
     private final ConfigurationDAO config;
     private RestClient client;
+    private final RestHighLevelClient restHighLevelClient;
     private final Gson gson;
 
     public ESService(ConfigurationDAO config){
         this.config = config;
         this.gson = new GsonBuilder().serializeNulls().create();
         logger.info("Initializing Elasticsearch client");
-        client = searchClient("es", "us-east-1");
-    }
-
-    // Base on host name to use signed request (AWS) or not (local)
-    public RestClient searchClient(String serviceName, String region) {
-        String host = config.getEsHost().trim();
-        String scheme = config.getEsScheme();
-        int port = config.getEsPort();
-        if (config.isEsSignRequests()) {
-            AWS4Signer signer = new AWS4Signer();
-            signer.setServiceName(serviceName);
-            signer.setRegionName(region);
-            HttpRequestInterceptor interceptor = new AWSRequestSigningApacheInterceptor(serviceName, signer, credentialsProvider);
-            return RestClient.builder(new HttpHost(host, port, scheme)).setHttpClientConfigCallback(hacb -> hacb.addInterceptorLast(interceptor)).build();
-        } else {
-            var lowLevelBuilder = RestClient.builder(new HttpHost(host, port, scheme));
-            return lowLevelBuilder.build();
-        }
+        // Base on host name to use signed request (AWS) or not (local)
+        AbstractClient abstractClient = config.isEsSignRequests() ? new AWSClient(config) : new DefaultClient(config);
+        restHighLevelClient = abstractClient.getElasticClient();
+        client = abstractClient.getLowLevelElasticClient();
     }
 
     @PreDestroy

--- a/src/main/java/gov/nih/nci/bento/service/connector/AWSClient.java
+++ b/src/main/java/gov/nih/nci/bento/service/connector/AWSClient.java
@@ -1,0 +1,41 @@
+package gov.nih.nci.bento.service.connector;
+
+import com.amazonaws.auth.AWS4Signer;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.http.AWSRequestSigningApacheInterceptor;
+import gov.nih.nci.bento.model.ConfigurationDAO;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequestInterceptor;
+import org.opensearch.client.RestClient;
+import org.opensearch.client.RestHighLevelClient;
+
+public class AWSClient extends AbstractClient {
+
+    static final AWSCredentialsProvider credentialsProvider = new DefaultAWSCredentialsProviderChain();
+
+    public AWSClient(ConfigurationDAO config) {
+        super(config);
+    }
+
+    @Override
+    public RestHighLevelClient getElasticClient() {
+        AWS4Signer signer = new AWS4Signer();
+        signer.setServiceName(config.getServiceName());
+        signer.setRegionName(config.getRegion());
+        HttpRequestInterceptor interceptor = new AWSRequestSigningApacheInterceptor(config.getServiceName(), signer, credentialsProvider);
+
+        return new RestHighLevelClient(
+                RestClient.builder(
+                        new HttpHost(config.getEsHost().trim(), config.getEsPort(), config.getEsScheme())).setHttpClientConfigCallback(hacb -> hacb.addInterceptorLast(interceptor)));
+    }
+
+    @Override
+    public RestClient getLowLevelElasticClient() {
+        AWS4Signer signer = new AWS4Signer();
+        signer.setServiceName(config.getServiceName());
+        signer.setRegionName(config.getRegion());
+        HttpRequestInterceptor interceptor = new AWSRequestSigningApacheInterceptor(config.getServiceName(), signer, credentialsProvider);
+        return RestClient.builder(new HttpHost(config.getEsHost().trim(), config.getEsPort(), config.getEsScheme())).setHttpClientConfigCallback(hacb -> hacb.addInterceptorLast(interceptor)).build();
+    }
+}

--- a/src/main/java/gov/nih/nci/bento/service/connector/AbstractClient.java
+++ b/src/main/java/gov/nih/nci/bento/service/connector/AbstractClient.java
@@ -1,0 +1,15 @@
+package gov.nih.nci.bento.service.connector;
+
+import gov.nih.nci.bento.model.ConfigurationDAO;
+import lombok.RequiredArgsConstructor;
+import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.client.RestClient;
+
+@RequiredArgsConstructor
+public abstract class AbstractClient {
+
+    protected final ConfigurationDAO config;
+
+    public abstract RestHighLevelClient getElasticClient();
+    public abstract RestClient getLowLevelElasticClient();
+}

--- a/src/main/java/gov/nih/nci/bento/service/connector/DefaultClient.java
+++ b/src/main/java/gov/nih/nci/bento/service/connector/DefaultClient.java
@@ -1,0 +1,26 @@
+package gov.nih.nci.bento.service.connector;
+
+import gov.nih.nci.bento.model.ConfigurationDAO;
+import org.apache.http.HttpHost;
+import org.opensearch.client.RestClient;
+import org.opensearch.client.RestHighLevelClient;
+
+public class DefaultClient extends AbstractClient {
+
+    public DefaultClient(ConfigurationDAO config) {
+        super(config);
+    }
+
+    @Override
+    public RestHighLevelClient getElasticClient() {
+        return new RestHighLevelClient(
+                RestClient.builder(
+                        new HttpHost(config.getEsHost().trim(), config.getEsPort(), config.getEsScheme())));
+    }
+
+    @Override
+    public RestClient getLowLevelElasticClient() {
+        var lowLevelBuilder = RestClient.builder(new HttpHost(config.getEsHost().trim(), config.getEsPort(), config.getEsScheme()));
+        return lowLevelBuilder.build();
+    }
+}


### PR DESCRIPTION
1. Abstract client to inject AWS or local opensearch highlevel client

2. Opensearch highlevel-client library: 2.2.0

note: Please add these variables in application.properties
 - es.service_name = "es"
 - es.region = "us-east-1"
